### PR TITLE
Bugfix unary minijit

### DIFF
--- a/src/mini_jit/generator/Unary.cpp
+++ b/src/mini_jit/generator/Unary.cpp
@@ -22,48 +22,108 @@ namespace mini_jit::generator {
 
     mini_jit::backend::Kernel Unary::m_kernel;
 
-    void Unary::gen_unary_transpose(uint32_t m, uint32_t n) {
-        int max_size = m * n;
-        int helper = 0;
+    void Unary::gen_transpose_micro( uint32_t i_m,
+                                     uint32_t i_n) {
+        // ldr
+        for( size_t i = 0; i < 4; i++){
+            m_kernel.add_instr(inst::InstGen::neon_ld1_no_offset( static_cast<inst::InstGen::simd_fp_t>(inst::InstGen::v0 + i),
+                                                                  inst::InstGen::x0,
+                                                                  inst::InstGen::vector_count_t::vc1));
+            m_kernel.add_instr(inst::InstGen::base_add_shifted_register(inst::InstGen::x0,
+                                                                        inst::InstGen::x0,
+                                                                        inst::InstGen::x2,
+                                                                        0,
+                                                                        0));
+        }
+        /* first part */
+        // trn 
+        m_kernel.add_instr(inst::InstGen::neon_trn(inst::InstGen::v4, inst::InstGen::v0, inst::InstGen::v1, 1));
+        m_kernel.add_instr(inst::InstGen::neon_trn(inst::InstGen::v5, inst::InstGen::v0, inst::InstGen::v1, 2));
+        m_kernel.add_instr(inst::InstGen::neon_trn(inst::InstGen::v6, inst::InstGen::v2, inst::InstGen::v3, 1));
+        m_kernel.add_instr(inst::InstGen::neon_trn(inst::InstGen::v7, inst::InstGen::v2, inst::InstGen::v3, 2));
 
-        // for all elements in a
-        for (int i = 0; i < max_size; i++) {
-            // copy from a to b
-            // TODO: This instructions are not implemented
-            // ldr x11, [x7]
-            m_kernel.add_instr(3107979499);
-            // str x11, [x8]
-            m_kernel.add_instr(3103785227);
+        // zip
+        m_kernel.add_instr(inst::InstGen::neon_zip(inst::InstGen::v8, inst::InstGen::v4, inst::InstGen::v6, 1));
+        m_kernel.add_instr(inst::InstGen::neon_zip(inst::InstGen::v9, inst::InstGen::v5, inst::InstGen::v7, 1));
+        m_kernel.add_instr(inst::InstGen::neon_zip(inst::InstGen::v10, inst::InstGen::v4, inst::InstGen::v6, 2));
+        m_kernel.add_instr(inst::InstGen::neon_zip(inst::InstGen::v11, inst::InstGen::v5, inst::InstGen::v7, 2));
 
-            // calc new element_b by adding the offset (size)
-            m_kernel.add_instr(inst::InstGen::base_add_imm(Util::WORKING_ADDRESS_B_REG, Util::WORKING_ADDRESS_B_REG, m * 4, 0));
-            helper += m;
 
-            // if the elements_b exeeds the maximum size
-            if (max_size - helper < 0) {
-                // start over
-                m_kernel.add_instr(inst::InstGen::base_sub_imm(Util::WORKING_ADDRESS_B_REG, Util::WORKING_ADDRESS_B_REG, max_size * 4, 0));
-                helper -= max_size;
 
-                // next element in b
-                m_kernel.add_instr(inst::InstGen::base_add_imm(Util::WORKING_ADDRESS_B_REG, Util::WORKING_ADDRESS_B_REG, 4, 0));
-                helper += 1;
-            }
-
-            // next element in a
-            m_kernel.add_instr(inst::InstGen::base_add_imm(Util::WORKING_ADDRESS_A_REG, Util::WORKING_ADDRESS_A_REG, 4, 0));
+        // str
+        for( size_t i = 0; i < 4; i++){
+            m_kernel.add_instr(inst::InstGen::neon_st1_no_offset(static_cast<inst::InstGen::simd_fp_t>(inst::InstGen::v8 + i),
+                                                                        inst::InstGen::x1,
+                                                                        inst::InstGen::vector_count_t::vc1));
+            m_kernel.add_instr(inst::InstGen::base_add_shifted_register(inst::InstGen::x1,
+                                                                        inst::InstGen::x1,
+                                                                        inst::InstGen::x3,
+                                                                        0,
+                                                                        0));
         }
     }
 
+    void Unary::gen_transpose( uint32_t i_m,
+                               uint32_t i_n){
+        /* get blocking */
+        uint32_t m_blocks_full = i_m / 4;
+        uint32_t m_blocks_reminder = i_m % 4;
+
+        uint32_t n_blocks_full = i_n / 4;
+        uint32_t n_blocks_reminder = i_n % 4;
+
+        // write restore size to x5 for A and x6 for B
+        m_kernel.add_instr(inst::InstGen::base_mov_imm(inst::InstGen::x5, 4, 0));
+        m_kernel.add_instr(inst::InstGen::base_mov_imm(inst::InstGen::x6, i_m, 0));
+        m_kernel.add_instr(inst::InstGen::base_mul_reg( inst::InstGen::x5,
+                                                        inst::InstGen::x5,
+                                                        inst::InstGen::x2 ));
+        m_kernel.add_instr(inst::InstGen::base_mul_reg( inst::InstGen::x6,
+                                                        inst::InstGen::x6,
+                                                        inst::InstGen::x3 ));   
+
+
+        for( uint32_t l_n = 0; l_n < n_blocks_full; l_n++){
+            for( uint32_t l_m = 0; l_m < m_blocks_full; l_m++ ){
+                gen_transpose_micro( 4, 4);
+                if( l_m < (m_blocks_full - 1)){
+                    m_kernel.add_instr(inst::InstGen::base_sub_shifted_register( inst::InstGen::x0,
+                                                                                inst::InstGen::x0,
+                                                                                inst::InstGen::x5,
+                                                                                0,
+                                                                                0));
+                    
+                    m_kernel.add_instr(inst::InstGen::base_add_imm( inst::InstGen::x0,
+                                                                    inst::InstGen::x0,
+                                                                    4 * 4,
+                                                                    0));
+                }
+            }
+            // adjust a and b pointer
+            m_kernel.add_instr( inst::InstGen::base_sub_imm( inst::InstGen::x0,
+                                                             inst::InstGen::x0,
+                                                             4 * 4 * (m_blocks_full - 1),
+                                                             0));
+        
+            
+            m_kernel.add_instr(inst::InstGen::base_sub_shifted_register( inst::InstGen::x1,
+                                                                         inst::InstGen::x1,
+                                                                         inst::InstGen::x6,
+                                                                         0,
+                                                                         0));
+            
+            m_kernel.add_instr( inst::InstGen::base_add_imm( inst::InstGen::x1,
+                                                             inst::InstGen::x1,
+                                                             4 * 4,
+                                                             0));
+        }
+    }
+    
+
     Unary::error_t Unary::generate(uint32_t m,
                                    uint32_t n,
-                                   uint32_t trans_b,
                                    Unary::dtype_t dtype,
                                    Unary::ptype_t ptype) {
-        // safely calculate number of iterations for main loop and number of rest elements
-        uint64_t total = static_cast<uint64_t>(m) * static_cast<uint64_t>(n);
-        uint32_t iterations = static_cast<uint32_t>((total - (total % 4)) / 16);
-        uint32_t rest = static_cast<uint32_t>(total % 16);
 
         // procedure call standard (store to stack)
         m_kernel.add_instr(0x6DBF27E8);
@@ -78,157 +138,11 @@ namespace mini_jit::generator {
                                                             inst::InstGen::x1));
 
         // shift leading dimensions to 4 bytes
-        m_kernel.add_instr(inst::InstGen::base_lsl_imm(inst::InstGen::x2, inst::InstGen::x2, 2));
-        m_kernel.add_instr(inst::InstGen::base_lsl_imm(inst::InstGen::x3, inst::InstGen::x3, 2));
+        m_kernel.add_instr(0xd37ef442);
+        m_kernel.add_instr(0xd37ef463);
 
-        if (!(ptype == Unary::ptype_t::identity) && !(trans_b == 1)) {
-            // move 0 to v31 for relu
-            m_kernel.add_instr(inst::InstGen::neon_movi_zero(inst::InstGen::simd_fp_t::v31, true, false));
-
-            // generate main loop
-            if (iterations > 0) {
-                // set loop counter, if number of iterations too high for immediate use movk
-                uint64_t value = iterations;
-                uint16_t lo = value & 0xffff;
-                uint16_t hi = (value >> 16) & 0xffff;
-
-                m_kernel.add_instr(inst::InstGen::base_movz(inst::InstGen::x9, lo, 0));  // movz x9, lo
-                if (hi != 0)
-                    m_kernel.add_instr(inst::InstGen::base_movk(inst::InstGen::x9, hi, 16));  // movk x9, hi, LSL #16
-
-                // loop
-                size_t loop_count = m_kernel.get_size();
-
-                m_kernel.add_instr(
-                    inst::InstGen::base_sub_imm(
-                        inst::InstGen::x9,
-                        inst::InstGen::x9,
-                        1,
-                        0));
-
-                m_kernel.add_instr(inst::InstGen::neon_ld1_multiple(inst::InstGen::v0,
-                                                                    inst::InstGen::x7,
-                                                                    inst::InstGen::ld1_opcode_t::four_regs,
-                                                                    inst::InstGen::ld1_t::S4));
-
-                if (ptype == Unary::ptype_t::zero) {
-                    m_kernel.add_instr(inst::InstGen::neon_movi_zero(inst::InstGen::v0, true, false));
-                    m_kernel.add_instr(inst::InstGen::neon_movi_zero(inst::InstGen::v1, true, false));
-                    m_kernel.add_instr(inst::InstGen::neon_movi_zero(inst::InstGen::v2, true, false));
-                    m_kernel.add_instr(inst::InstGen::neon_movi_zero(inst::InstGen::v3, true, false));
-                    this->fops += 4;
-                } else if (ptype == Unary::ptype_t::relu) {
-                    m_kernel.add_instr(inst::InstGen::neon_fmax_vector(inst::InstGen::v0,
-                                                                       inst::InstGen::v0,
-                                                                       inst::InstGen::simd_fp_t::v31,
-                                                                       false));
-                    m_kernel.add_instr(inst::InstGen::neon_fmax_vector(inst::InstGen::v1,
-                                                                       inst::InstGen::v1,
-                                                                       inst::InstGen::simd_fp_t::v31,
-                                                                       false));
-                    m_kernel.add_instr(inst::InstGen::neon_fmax_vector(inst::InstGen::v2,
-                                                                       inst::InstGen::v2,
-                                                                       inst::InstGen::simd_fp_t::v31,
-                                                                       false));
-                    m_kernel.add_instr(inst::InstGen::neon_fmax_vector(inst::InstGen::v3,
-                                                                       inst::InstGen::v3,
-                                                                       inst::InstGen::simd_fp_t::v31,
-                                                                       false));
-                    this->fops += 4;
-                }
-
-                m_kernel.add_instr(inst::InstGen::neon_st1_multiple(inst::InstGen::v0,
-                                                                    inst::InstGen::x8,
-                                                                    inst::InstGen::ld1_opcode_t::four_regs,
-                                                                    inst::InstGen::ld1_t::S4));
-
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x7, inst::InstGen::x7, 4 * 16, 0));
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x8, inst::InstGen::x8, 4 * 16, 0));
-
-                // jump loop
-                m_kernel.add_instr(inst::InstGen::base_br_cbnz(inst::InstGen::x9, (loop_count - m_kernel.get_size()) / 4));
-            }
-
-            // try to use ld1 with as many registers as possible for rest (rest in [0, 15])
-            uint32_t next_bigger = rest;
-
-            while (next_bigger % 4 != 0) {
-                next_bigger--;
-            }
-
-            inst::InstGen::ld1_opcode_t num_regs;
-
-            if (next_bigger == 12) {
-                num_regs = inst::InstGen::ld1_opcode_t::three_regs;
-            } else if (next_bigger == 8) {
-                num_regs = inst::InstGen::ld1_opcode_t::two_regs;
-            } else if (next_bigger == 4) {
-                num_regs = inst::InstGen::ld1_opcode_t::one_regs;
-            }
-
-            if (next_bigger > 0) {
-                m_kernel.add_instr(inst::InstGen::neon_ld1_multiple(inst::InstGen::v0,
-                                                                    inst::InstGen::x7,
-                                                                    num_regs,
-                                                                    inst::InstGen::ld1_t::S4));
-
-                int32_t reg_count = 0;
-
-                for (int i = 0; i < (int)(next_bigger / 4); i++) {
-                    if (ptype == Unary::ptype_t::zero) {
-                        m_kernel.add_instr(inst::InstGen::neon_movi_zero(static_cast<inst::InstGen::simd_fp_t>(reg_count++), true, false));
-                    } else if (ptype == Unary::ptype_t::relu) {
-                        m_kernel.add_instr(inst::InstGen::neon_fmax_vector(static_cast<inst::InstGen::simd_fp_t>(reg_count),
-                                                                           static_cast<inst::InstGen::simd_fp_t>(reg_count),
-                                                                           inst::InstGen::simd_fp_t::v31,
-                                                                           false));
-                        reg_count++;
-                    }
-                }
-
-                m_kernel.add_instr(inst::InstGen::neon_st1_multiple(inst::InstGen::v0,
-                                                                    inst::InstGen::x8,
-                                                                    num_regs,
-                                                                    inst::InstGen::ld1_t::S4));
-
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x7, inst::InstGen::x7, 4 * next_bigger, 0));
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x8, inst::InstGen::x8, 4 * next_bigger, 0));
-            }
-
-            // final rest (in [0, 3]) with single ld1 statements per element
-            int32_t reg_count = 0;
-            rest = (uint32_t)std::abs((int)next_bigger - (int)rest);
-            for (int i = 0; i < rest; i++) {
-                m_kernel.add_instr(
-                    inst::InstGen::neon_ld1_no_offset(
-                        static_cast<inst::InstGen::simd_fp_t>(i),
-                        inst::InstGen::x7,
-                        inst::InstGen::vector_count_t::vc1));
-
-                if (ptype == Unary::ptype_t::zero) {
-                    m_kernel.add_instr(inst::InstGen::neon_movi_zero(static_cast<inst::InstGen::simd_fp_t>(reg_count++), true, false));
-                } else if (ptype == Unary::ptype_t::relu) {
-                    m_kernel.add_instr(inst::InstGen::neon_fmax_vector(static_cast<inst::InstGen::simd_fp_t>(reg_count),
-                                                                       static_cast<inst::InstGen::simd_fp_t>(reg_count),
-                                                                       inst::InstGen::simd_fp_t::v31,
-                                                                       false));
-                    reg_count++;
-                }
-                m_kernel.add_instr(
-                    inst::InstGen::neon_st1_no_offset(
-                        static_cast<inst::InstGen::simd_fp_t>(i),
-                        inst::InstGen::x8,
-                        inst::InstGen::vector_count_t::vc1));
-
-                // advance the base pointer by 1 elements
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x7, inst::InstGen::x7, 4, 0));
-                m_kernel.add_instr(inst::InstGen::base_add_imm(inst::InstGen::x8, inst::InstGen::x8, 4, 0));
-            }
-
-            // Transpose
-        } else {
-            gen_unary_transpose(m, n);
-        }
+        gen_transpose( m,
+                       n);
 
         // procedure call standard (load from stack)
         m_kernel.add_instr(0x6CC13FEE);

--- a/src/mini_jit/generator/Unary.h
+++ b/src/mini_jit/generator/Unary.h
@@ -41,6 +41,10 @@ class mini_jit::generator::Unary {
 
     void gen_transpose( uint32_t i_m,
                                uint32_t i_n);
+    
+    void gen_zero();
+
+    void gen_relu();
 
     /**
      * @brief Generate a kernel for a unary primitive.

--- a/src/mini_jit/generator/Unary.h
+++ b/src/mini_jit/generator/Unary.h
@@ -14,10 +14,6 @@ class mini_jit::generator::Unary {
    private:
     static mini_jit::backend::Kernel m_kernel;
 
-    static int32_t gen_unary_zero(mini_jit::generator::Util::KernelSize kernelsize);
-    static int32_t gen_unary_relu(mini_jit::generator::Util::KernelSize kernelsize);
-    static void gen_unary_transpose(uint32_t m, uint32_t n);
-
    public:
     int32_t fops = 0;
 
@@ -31,7 +27,8 @@ class mini_jit::generator::Unary {
     enum class ptype_t : uint32_t {
         zero = 0,
         identity = 1,
-        relu = 2
+        relu = 2,
+        trans = 3
     };
 
     /// error codes
@@ -39,17 +36,11 @@ class mini_jit::generator::Unary {
         success = 0
     };
 
-    /**
-     * @brief Get kernel sizes for sub-matrices.
-     * @param m            Number of rows in A and B.
-     * @param n            Number of columns in A and B.
-     * @param kernel_sizes size for each kernel for the sub-matrices.
-     * @return error_t::success on success, another error_t value otherwise.
-     **/
-    static error_t get_kernel_sizes(uint32_t m,
-                                    uint32_t n,
-                                    Util::KernelSizes& kernel_sizes,
-                                    bool only_square = false);
+    void gen_transpose_micro( uint32_t i_m,
+                              uint32_t i_n);
+
+    void gen_transpose( uint32_t i_m,
+                               uint32_t i_n);
 
     /**
      * @brief Generate a kernel for a unary primitive.
@@ -62,7 +53,6 @@ class mini_jit::generator::Unary {
      **/
     error_t generate(uint32_t m,
                      uint32_t n,
-                     uint32_t trans_b,
                      dtype_t dtype,
                      ptype_t ptype);
 

--- a/src/mini_jit/instructions/instructions.h
+++ b/src/mini_jit/instructions/instructions.h
@@ -339,5 +339,8 @@ class mini_jit::instructions::InstGen {
                               simd_fp_t reg_src1,
                               simd_fp_t reg_src2,
                               int variant /* 1 or 2 */);
+    static uint32_t neon_eor( simd_fp_t reg_dst,
+                              simd_fp_t reg_src1,
+                              simd_fp_t reg_src2 );
 };
 #endif

--- a/src/mini_jit/instructions/instructions.h
+++ b/src/mini_jit/instructions/instructions.h
@@ -330,5 +330,14 @@ class mini_jit::instructions::InstGen {
                                       gpr_t src_reg,
                                       ld1_opcode_t op_code,
                                       ld1_t element);
+
+    static uint32_t neon_trn( simd_fp_t reg_dst,
+                              simd_fp_t reg_src1,
+                              simd_fp_t reg_src2,
+                              int variant /* 1 or 2 */);
+    static uint32_t neon_zip( simd_fp_t reg_dst,
+                              simd_fp_t reg_src1,
+                              simd_fp_t reg_src2,
+                              int variant /* 1 or 2 */);
 };
 #endif

--- a/src/mini_jit/instructions/neon.cpp
+++ b/src/mini_jit/instructions/neon.cpp
@@ -326,3 +326,17 @@ uint32_t mini_jit::instructions::InstGen::neon_zip( simd_fp_t reg_dst,
 
     return l_ins;
 }
+
+uint32_t mini_jit::instructions::InstGen::neon_eor( simd_fp_t reg_dst,
+                                                    simd_fp_t reg_src1,
+                                                    simd_fp_t reg_src2){
+    uint32_t l_ins = 0x6e201c00;
+
+    l_ins |= (reg_dst & 0x1f);
+    l_ins |= (reg_src1 & 0x1f) << 5;
+    l_ins |= (reg_src2 & 0x1f) << 16;
+
+    return l_ins;
+
+
+}

--- a/src/mini_jit/instructions/neon.cpp
+++ b/src/mini_jit/instructions/neon.cpp
@@ -281,3 +281,48 @@ uint32_t mini_jit::instructions::InstGen::neon_st1_multiple(simd_fp_t reg_base,
 
     return l_ins;
 }
+
+
+uint32_t mini_jit::instructions::InstGen::neon_trn( simd_fp_t reg_dst,
+                                                   simd_fp_t reg_src1,
+                                                   simd_fp_t reg_src2,
+                                                   int variant /* 1 or 2 */) {
+    uint32_t l_ins = 0;
+
+    if( variant == 1) {
+        l_ins = 0x4e802800; // TRN1
+    } else if( variant == 2) {
+        l_ins = 0x4e806800; // TRN2
+    } else {
+        std::cerr << "Invalid variant for TRN instruction: " << variant << std::endl;
+        return 0; // Invalid variant
+    }
+
+    l_ins |= (reg_dst & 0x1f);
+    l_ins |= (reg_src1 & 0x1f) << 5;
+    l_ins |= (reg_src2 & 0x1f) << 16;
+    
+    return l_ins;
+}
+
+uint32_t mini_jit::instructions::InstGen::neon_zip( simd_fp_t reg_dst,
+                                                   simd_fp_t reg_src1,
+                                                   simd_fp_t reg_src2,
+                                                   int variant /* 1 or 2 */) {
+    uint32_t l_ins = 0;
+
+    if( variant == 1) {
+        l_ins = 0x4ec03800; // ZIP1
+    } else if( variant == 2) {
+        l_ins = 0x4ec07800; // ZIP2
+    } else {
+        std::cerr << "Invalid variant for ZIP instruction: " << variant << std::endl;
+        return 0; // Invalid variant
+    }
+
+    l_ins |= (reg_dst & 0x1f);
+    l_ins |= (reg_src1 & 0x1f) << 5;
+    l_ins |= (reg_src2 & 0x1f) << 16;
+
+    return l_ins;
+}


### PR DESCRIPTION
Fixed a few problems with unary JIT operations.
Transpose only works with multiples of 4 and relu assumes that vector register 31 is not relevant.